### PR TITLE
refactor: Beautify colour palette 

### DIFF
--- a/index.html
+++ b/index.html
@@ -20,14 +20,14 @@
             <div id="input-container">
                 <!-- Displays user selection -->
                 <div class="letter-container" id="selection-container">
-                    <div class="letter letter-selection unselected">_</div>
-                    <div class="letter letter-selection unselected">_</div>
-                    <div class="letter letter-selection unselected">_</div>
-                    <div class="letter letter-selection unselected">_</div>
-                    <div class="letter letter-selection unselected">_</div>
-                    <div class="letter letter-selection unselected">_</div>
-                    <div class="letter letter-selection unselected">_</div>
-                    <div class="letter letter-selection unselected">_</div>
+                    <div class="letter letter-selection letter-unselected">_</div>
+                    <div class="letter letter-selection letter-unselected">_</div>
+                    <div class="letter letter-selection letter-unselected">_</div>
+                    <div class="letter letter-selection letter-unselected">_</div>
+                    <div class="letter letter-selection letter-unselected">_</div>
+                    <div class="letter letter-selection letter-unselected">_</div>
+                    <div class="letter letter-selection letter-unselected">_</div>
+                    <div class="letter letter-selection letter-unselected">_</div>
                 </div>
                 <!-- Displays user input letters -->
                 <div class="letter-container">

--- a/index.html
+++ b/index.html
@@ -10,17 +10,6 @@
 
     <body>
         <div id="main-container">
-            <!-- Displays user selection -->
-            <div class="letter-container" id="selection-container">
-                <div class="letter letter-selection unselected">_</div>
-                <div class="letter letter-selection unselected">_</div>
-                <div class="letter letter-selection unselected">_</div>
-                <div class="letter letter-selection unselected">_</div>
-                <div class="letter letter-selection unselected">_</div>
-                <div class="letter letter-selection unselected">_</div>
-                <div class="letter letter-selection unselected">_</div>
-                <div class="letter letter-selection unselected">_</div>
-            </div>
             <!-- Displays user's word outputs -->
             <div id="output-container">
                 <!-- Dud containers to pad the output -->
@@ -28,8 +17,19 @@
                 <div class="letter-container"></div>
                 <div class="letter-container"></div>
             </div>
-            <!-- Displays user input letters -->
             <div id="input-container">
+                <!-- Displays user selection -->
+                <div class="letter-container" id="selection-container">
+                    <div class="letter letter-selection unselected">_</div>
+                    <div class="letter letter-selection unselected">_</div>
+                    <div class="letter letter-selection unselected">_</div>
+                    <div class="letter letter-selection unselected">_</div>
+                    <div class="letter letter-selection unselected">_</div>
+                    <div class="letter letter-selection unselected">_</div>
+                    <div class="letter letter-selection unselected">_</div>
+                    <div class="letter letter-selection unselected">_</div>
+                </div>
+                <!-- Displays user input letters -->
                 <div class="letter-container">
                     <div class="letter letter-btn" id="letter-btn-0" onclick="select_letter_btn(0)"></div>
                     <div class="letter letter-btn" id="letter-btn-1" onclick="select_letter_btn(1)"></div>

--- a/script.js
+++ b/script.js
@@ -80,8 +80,8 @@ function select_letter_btn(tile_index){
     if(tile.selected) return
     tile.select()
     SELECTION.push(tile.char)
-    selection_tile = document.getElementsByClassName('letter-selection unselected')[0]
-    selection_tile.classList.remove('unselected')
+    selection_tile = document.getElementsByClassName('letter-selection letter-unselected')[0]
+    selection_tile.classList.remove('letter-unselected')
     selection_tile.innerText = tile.char
 }
 
@@ -90,7 +90,7 @@ function clear_selection(){
     selection_tiles = document.getElementsByClassName('letter-selection')
     for(var i = 0; i < selection_tiles.length; i++){
         selection_tiles[i].innerText = DEFAULT_SELECTION_CHAR
-        selection_tiles[i].classList.add('unselected')
+        selection_tiles[i].classList.add('letter-unselected')
     }
     // Visually reset input letters
     INPUT_CHARS.forEach(element => {

--- a/style.css
+++ b/style.css
@@ -1,5 +1,5 @@
 body {
-    background: rgb(20,20,20);
+    background: rgb(30,35,30);
     font-family: monospace;
     font-size: 0px;
     font-weight: bold;
@@ -37,7 +37,7 @@ body {
     width: 12.5%;
     display: inline-flex;
     background: black;
-    border: 2px solid white;
+    border: 2px solid rgb(245,245,245);
     box-sizing: border-box;
     font-size: 24px;
     align-items: center;
@@ -45,8 +45,9 @@ body {
 }
 
 .output-letter{
-    background: rgb(50,50,50);
-    color: rgb(210,210,210);
+    background: rgb(70,78,70);
+    color: rgb(245,245,245);
+    border-color: rgb(245,245,245);
 }
 
 #input-container{
@@ -60,7 +61,6 @@ body {
     position: relative;
     width: 100%;
     aspect-ratio: 8/1;
-    background: green;
 }
 
 .btn{
@@ -74,7 +74,7 @@ body {
     justify-content: center;
     cursor: pointer;
     background: black;
-    border: 2px solid white;
+    border: 2px solid rgb(245,245,245);
     box-sizing: border-box;
 }
 

--- a/style.css
+++ b/style.css
@@ -89,5 +89,14 @@ body {
 }
 
 .letter-btn-selected{
+    background: lightgrey;
+    color: rgb(160,160,160);
+}
+
+.letter-selection{
     background: rgb(2, 172, 132);
+}
+
+.letter-unselected{
+    background: black;
 }

--- a/style.css
+++ b/style.css
@@ -90,8 +90,8 @@ body {
 }
 
 .letter-btn-selected{
-    background: lightgrey;
-    color: rgb(160,160,160);
+    background: rgb(245,245,245);
+    color: rgb(245,245,245);
 }
 
 .letter-selection{

--- a/style.css
+++ b/style.css
@@ -55,6 +55,7 @@ body {
     bottom: 0;
     width: 100%;
     background: white;
+    box-shadow: 0px -10px 25px rgb(30,30,30);
 }
 
 .btn-container{

--- a/style.css
+++ b/style.css
@@ -11,13 +11,13 @@ body {
 #main-container{
     position: absolute;
     left: 50%;
-    width: 800px;
-    margin-left: -400px;
+    width: 600px;
+    margin-left: -300px;
     height: 100%;
     overflow: hidden;
 }
 
-@media only screen and (max-width: 900px) {
+@media only screen and (max-width: 700px) {
     #main-container {
         width: 100%;
         margin-left: 0;

--- a/style.css
+++ b/style.css
@@ -92,6 +92,7 @@ body {
 .letter-btn-selected{
     background: rgb(245,245,245);
     color: rgb(245,245,245);
+    cursor: auto;
 }
 
 .letter-selection{


### PR DESCRIPTION
# refactor(input): Move selection-container to the bottom

I found myself glancing up at the output repeatedly while inputting
letters, particularly on mobile. I think this is because the input
letters are obviously non-standard vs a qwerty keyboard, so one has to
look at both the input and the output letters simultaneously to ensure
the correct word is being entered.

By placing the output above the input, the UX of entering a word should
be improved.

Incidentally, the CSS is clearly working well because this was a super
trivial move which aligned nicely with the existing layout.

# refactor: Identify selection with colour

Currently, when selected, the letter buttons are highlighted green and
the output letters remain black. This use of colour doesn't give the
user much visual help.

Instead, when selected, the letter buttons turn grey to signify they
have been used and the output letters turn green to signify that they
have been activated.

This should give the player better feedback about the action they have
just taken.

# refactor(screen): Reduce width

On larger screens like desktops, the screen is a bit too wide. It looks
almost enlarged or stretched.

This ensures the proportions are roughly maintained on larger screens.

# refactor: Shift the colour palette to green

The game is looking a little grey, so this should make it visually less
boring. The selected selection letters are already green, so I'm leaning
towards green.

Tried to make the output letters sort of "inactive" but at the same time
visible.

Also made the border and text colour off-white to reduce the sharp
contrast with the background.

# refactor(input-container): Introduce box-shadow

This adds a bit of separation between the output letters and input
letters without adding another border. Also a bit of depth to an
otherwise very flat game!

# refactor(input-selection): Make letter btns disappear

Rather than simply greying out the selected tiles, this (visually)
removes them from the input container entirely! I find the input
container a bit of an overwhelming mess of letters currently, so this
reduces some of the visual noise.

# refactor(letter-btn-selected): Remove cursor

When the letter disappears, the letter can no longer be selected so the
cursor can be removed.