### PR TITLE
feat: Add new-game button

### DIFF
--- a/index.html
+++ b/index.html
@@ -12,6 +12,7 @@
         <div id="main-container">
             <!-- Displays user's word outputs -->
             <div id="output-container">
+                <div id="output-container-words"></div>
                 <!-- Dud containers to pad the output -->
                 <div class="letter-container"></div>
                 <div class="letter-container"></div>

--- a/index.html
+++ b/index.html
@@ -42,10 +42,10 @@
                     <div class="letter letter-btn" id="letter-btn-7" onclick="select_letter_btn(7)"></div>
                 </div>
                 <div class="btn-container">
-                    <div class="btn" onclick="clear_selection()"><i class="fa-solid fa-trash"></i></div>
-                    <div class="btn" onclick="quit_game()"><i class="fa-solid fa-times"></i></div>
+                    <div class="btn btn-danger" onclick="new_game()"><i class="fa-solid fa-times"></i></div>
+                    <div class="btn" onclick="clear_selection()"><i class="fa-solid fa-undo"></i></div>
                     <div class="btn" onclick="shuffle_selection()"><i class="fa-solid fa-shuffle"></i></div>
-                    <div class="btn" onclick="enter_selection()"><i class="fa-solid fa-play"></i></div>
+                    <div class="btn btn-success" onclick="enter_selection()"><i class="fa-solid fa-play"></i></div>
                 </div>
             </div>
         </div>

--- a/script.js
+++ b/script.js
@@ -75,7 +75,7 @@ function get_letter_container_el(letters){
 
 function render_word_output(letters){
     letter_container_el = get_letter_container_el(letters)
-    output_container = document.getElementById('output-container')
+    output_container = document.getElementById('output-container-words')
     output_container.innerHTML = letter_container_el + output_container.innerHTML
 }
 

--- a/script.js
+++ b/script.js
@@ -132,6 +132,17 @@ function shuffle_selection(){
     }
 }
 
-window.onload = function(){
+function new_game(){
+    // Clear selection container
+    clear_selection()
+    // Clear any found words
+    FOUND_WORDS = []
+    // Clear visual found words
+    document.getElementById('output-container-words').innerHTML = ''
+    // Reset input chars
     INPUT_CHARS = generate_game_data(SELECTION_COUNT)
+}
+
+window.onload = function(){
+    new_game()
 }

--- a/style.css
+++ b/style.css
@@ -79,6 +79,14 @@ body {
     box-sizing: border-box;
 }
 
+.btn-success{
+    background:rgb(2, 172, 132);
+}
+
+.btn-danger{
+    background:rgb(172, 2, 70)
+}
+
 #output-container{
     height: 100%;
     width: 100%;


### PR DESCRIPTION
# refactor(output-container): Add explicit output word container

Currently if we clear the `output-container`, the padding (and any other
content) will also be cleared.

When we clear the output container, we only want the output words to be
cleared, no the padding.

This ensures the output words are added to their own dedicated
container. If we clear this container, only the output words are
cleared. The padding is retained.

# feat: Add new-game button

This will reset the game to the starting state, with a new series of
input letters.

This is obviously a dangerous action, so I've made the reset button
explciitly dangerous (red). To compliment this style, I've made the
"submit" button green.

I've also changed the "clear" button icon from a bin to an "undo" icon
to differentiate its purpose from the "new game" button.